### PR TITLE
feat!: upgrade edx-drf-extensions and pyjwt to latest versions

### DIFF
--- a/notesserver/settings/common.py
+++ b/notesserver/settings/common.py
@@ -140,5 +140,6 @@ JWT_AUTH = {
     'JWT_PUBLIC_SIGNING_JWK_SET': None,
     'JWT_AUTH_COOKIE_HEADER_PAYLOAD': 'edx-jwt-cookie-header-payload',
     'JWT_AUTH_COOKIE_SIGNATURE': 'edx-jwt-cookie-signature',
-    'JWT_AUTH_REFRESH_COOKIE': 'edx-jwt-refresh-cookie'
+    'JWT_AUTH_REFRESH_COOKIE': 'edx-jwt-refresh-cookie',
+    'JWT_ALGORITHM': 'HS256',
 }


### PR DESCRIPTION
BREAKING CHANGES (pyjwt):
- ``jwt.decode``: requires explicit algorithms argument.
- ``jwt.decode``: Returns string (in place of bytes), and no longer requires decoding.
- ExpiredSignatureError is dropped and replaced with ExpiredSignatureError
- For more details, visit this: https://pyjwt.readthedocs.io/en/stable/changelog.html#v2-1-0